### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-#Blueprint: Touch-friendly Product Grid Layout with Filter Functionality
+# Blueprint: Touch-friendly Product Grid Layout with Filter Functionality
 
 A responsive product grid layout with touch-friendly Flickity galleries and Isotope-powered filter functionality.
 


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
